### PR TITLE
[stable8] Fix share button display

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -25,7 +25,7 @@
 		},
 
 		hide: function() {
-			$('#pdframe, #pdfbar').remove();
+			$('#pdframe').remove();
 			if ($('#isPublic').val() && $('#filesApp').val()){
 				$('#controls').removeClass('hidden');
 			}
@@ -43,8 +43,9 @@
 		show: function(downloadUrl, isFileList) {
 			var self = this;
 			var $iframe;
+
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: encodeURIComponent(downloadUrl)});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin" /><div id="pdfbar"><a id="close" title="Close">X</a></div>');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin" />');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);
@@ -66,15 +67,18 @@
 			$("#pageWidthOption").attr("selected","selected");
 			// replace the controls with our own
 			$('#app-content #controls').addClass('hidden');
-			$('#pdfbar').css({position:'absolute',top:'6px',right:'5px'});
+
 			// if a filelist is present, the PDF viewer can be closed to go back there
-			if ($('#fileList').length) {
-				$('#close').css({display:'block',padding:'0 5px',color:'#BBBBBB','font-weight':'900','font-size':'16px',height:'18px',background:'transparent'}).click(function(){
-					self.hide();
-				});
-			} else {
-				$('#close').addClass('hidden');
-			}
+			$('#pdframe').load(function(){
+				var iframe = $('#pdframe').contents();
+				if ($('#fileList').length) {
+					iframe.find('#close').click(function() {
+						self.hide();
+					});
+				} else {
+					iframe.find("#close").addClass('hidden');
+				}
+			});
 		},
 
 		/**

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -192,6 +192,10 @@ http://sourceforge.net/adobe/cmap/wiki/License/
                   <span data-l10n-id="tools_label">Tools</span>
                 </button>
 
+                <button id="close" class="toolbarButton" title="Close" tabindex="37" data-l10n-id="Close" style="display:block;padding:0 5px;color:#BBBBBB;font-weight:900;font-size:16px;height:18px;top:4px;">
+                     X
+                </button>
+
               </div>
               <div class="outerCenter">
                 <div class="innerCenter" id="toolbarViewerMiddle">


### PR DESCRIPTION
With ownCloud 8 the "Close" button of the PDF Viewer is shown incorrectly and overlaps the "secondary tool bar" button  which results in a bad user experience and looks very ugly.

This patch addresses this problem by moving the "Close" button inside the iframe and accessing it using jQuery.

Testplan:

- [ ] Accessing a PDF as logged-in user from the file list works and a Close button is shown.
  - [ ] Clicking on the close button closes the file
- [ ] Sharing a single PDF file via link works and no Close button is shown
- [ ] Sharing a folder containing a PDF file via link works and a Close button is shown.
   - [ ] Clicking on the close button closes the file

cc @PVince81 @nickvergessen Please test.