### PR TITLE
Fix download with Firefox

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -44,7 +44,7 @@
 			var self = this;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin" />');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups" />');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);


### PR DESCRIPTION
Hi,

With Firefox (reproduce with versions 31 and 36), we can't download file using download button in PDF.js when Firefox is configure to alway ask on PDF file download. In this case, clicking on download button have no effect and nothing is logged in browser console.

To fix this bug, we add "allow-popups" to iframe's sandbox attribute.