### PR TITLE
Add listener for URL change and then close the PDF viewer

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -72,12 +72,26 @@
 				var iframe = $('#pdframe').contents();
 				if ($('#fileList').length) {
 					iframe.find('#secondaryToolbarClose').click(function() {
-						self.hide();
+						if(!$('html').hasClass('ie8')) {
+							history.back();
+						} else {
+							self.hide();
+						}
 					});
 				} else {
 					iframe.find("#secondaryToolbarClose").addClass('hidden');
 				}
 			});
+
+			if(!$('html').hasClass('ie8')) {
+				history.pushState({}, '', '#pdfviewer');
+			}
+
+			if(!$('html').hasClass('ie8')) {
+				$(window).one('popstate', function (e) {
+					self.hide();
+				});
+			}
 		},
 
 		/**


### PR DESCRIPTION
Currently this doesn't only close the pdfviewer but only goes one step further. If you previously browsed to a folder and opened the PDF in there it will close the viewer and go to the parent directory on back button press. This is better than before where the pdfviewer is still open and the content is visible as overlay.

cc @LukasReschke 


@PVince81 Is there a more elegant way to do this?