### PR TITLE
Remove white area below pdf viewer on public page

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -13,3 +13,4 @@ namespace OCA\Files_PdfViewer\AppInfo;
 use OCP\Util;
 
 Util::addScript('files_pdfviewer', 'previewplugin');
+Util::addStyle('files_pdfviewer', 'style');

--- a/css/style.css
+++ b/css/style.css
@@ -1,17 +1,4 @@
-.toolbarButton#secondaryToolbarClose::before {
-  display: block;
-  content: ' ';
-  background-image: url(../img/toolbarButton-secondaryToolbarClose.svg);
-  background-size: 32px 32px;
-  height: 32px;
-  width: 32px;
-
-}
-
-
-html .doorHangerRight:after {
-  right: 53px!important;
-}
-html .doorHangerRight:before {
-  right: 53px!important;
+/* force full height on public template */
+#body-public #content {
+    height: 100%;
 }

--- a/css/viewer.css
+++ b/css/viewer.css
@@ -1,0 +1,17 @@
+.toolbarButton#secondaryToolbarClose::before {
+  display: block;
+  content: ' ';
+  background-image: url(../img/toolbarButton-secondaryToolbarClose.svg);
+  background-size: 32px 32px;
+  height: 32px;
+  width: 32px;
+
+}
+
+
+html .doorHangerRight:after {
+  right: 53px!important;
+}
+html .doorHangerRight:before {
+  right: 53px!important;
+}

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -31,7 +31,7 @@ http://sourceforge.net/adobe/cmap/wiki/License/
     <title>PDF.js viewer</title>
 
     <link rel="stylesheet" href="<?php p($urlGenerator->linkTo('files_pdfviewer', 'vendor/pdfjs/web/viewer.css')) ?>?v=<?php p($version) ?>"/>
-    <link rel="stylesheet" href="<?php p($urlGenerator->linkTo('files_pdfviewer', 'css/style.css')) ?>?v=<?php p($version) ?>"/>
+    <link rel="stylesheet" href="<?php p($urlGenerator->linkTo('files_pdfviewer', 'css/viewer.css')) ?>?v=<?php p($version) ?>"/>
 
     <script src="<?php p($urlGenerator->linkTo('files_pdfviewer', 'vendor/pdfjs/web/compatibility.js')) ?>?v=<?php p($version) ?>"></script>
     <!-- This snippet is used in production (included from viewer.html) -->
@@ -413,4 +413,3 @@ http://sourceforge.net/adobe/cmap/wiki/License/
 
   </body>
 </html>
-


### PR DESCRIPTION
fixes owncloud/core#20557

comment on diff: I moved `style.css` to `viewer.css` and added a new `style.css`

Please review @LukasReschke @PVince81 @owncloud/designers 