### PR TITLE
Add minimum and maximum required versions

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,9 @@
     </description>
     <licence>AGPL</licence>
     <author>Thomas Müller, Lukas Reschke</author>
-    <require>8.0</require>
+	<dependencies>
+		<owncloud min-version="9.0" max-version="9.0" />
+	</dependencies>
     <shipped>true</shipped>
     <default_enable/>
     <ocsid>166049</ocsid>


### PR DESCRIPTION
Fixes "This app has no minimum ownCloud version assigned. This will be an error in ownCloud 11 and later."

@nickvergessen @MorrisJobke 