### PR TITLE
Fix for IE to remove second scrollbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,3 +2,7 @@
 #body-public .full-height {
 	height: 100%;
 }
+.ie #body-public .full-height {
+	display: block;
+}
+


### PR DESCRIPTION
- [x] REQUIRES: https://github.com/owncloud/core/pull/22561

The fix above is needed to make the footer work in IE. However it introduces a second scrollbar due to the "new" layout configuration.

This fix sets the "display" property back when using the PDF viewer.