### PR TITLE
z-index on pdframe to avoid bleed-through images

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -46,7 +46,7 @@
 			var self = this;
 			var $iframe;
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {file: downloadUrl});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals" />');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:10;" src="'+viewer+'" sandbox="allow-scripts allow-same-origin allow-popups allow-modals" />');
 
 			if(isFileList === true) {
 				FileList.setViewerMode(true);


### PR DESCRIPTION
When searching for files using the new tag system and then clicking on a PDF file in the results to see the rendered version in pdf.js, the icons from the search result screen show through. Those search-result icons have a z-index set to 4, while the pdframe created here does not presently have a z-index set (so I believe it defaults to "0"). Setting this to 10 as indicated in this pull-request fixes the issue for me.