### PR TITLE
[release-0.9.0] Add changelog with entries for 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+## [0.9.0] - 2018-07-18
+
+### Added
+- Apply current locale to PDF viewer - [#149](https://github.com/owncloud/files_pdfviewer/pull/149)
+
+### Changed
+- Update pdfjs to the most recent stable 1.9.426 - [#146](https://github.com/owncloud/files_pdfviewer/issues/146) [#152](https://github.com/owncloud/files_pdfviewer/issues/152)
+
+### Removed
+- Removed IE8 support - [#149](https://github.com/owncloud/files_pdfviewer/pull/149)
+- Removed "Open document" from within the viewer - [#149](https://github.com/owncloud/files_pdfviewer/pull/149)
+
+### Fixed
+- Fix missing tool buttons - [#116](https://github.com/owncloud/files_pdfviewer/issues/116)
+- Fix closing of PDF viewer - [#142](https://github.com/owncloud/files_pdfviewer/issues/142)
+
+## 0.8.2
+### Changed
+- First marketplace release
+
+[Unreleased]: https://github.com/owncloud/password_policy/compare/v0.9.0..HEAD
+[0.9.0]: https://github.com/owncloud/password_policy/compare/v0.8.2..v0.9.0
+

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,7 @@
         about the PDF.js project at https://mozilla.github.io/pdf.js/
     </description>
     <licence>AGPL</licence>
-    <author>Thomas Müller, Lukas Reschke</author>
+    <author>Thomas Müller, Lukas Reschke, Viktar Dubiniuk</author>
     <version>0.9.0</version>
     <dependencies>
         <owncloud min-version="10.0" max-version="11.0" />

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,6 +2,7 @@
 <info>
     <id>files_pdfviewer</id>
     <name>PDF Viewer</name>
+    <summary>Online viewer for PDF files</summary>
     <description>
 This application integrates the PDF.js library into ownCloud. Using this application users can view their PDF files in their browser without the need to download the file.
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,17 +3,11 @@
     <id>files_pdfviewer</id>
     <name>PDF Viewer</name>
     <description>
-        This application integrates the PDF.js library into ownCloud. Using this
-        application users can view their PDF files online without the need to
-        download the file.
+This application integrates the PDF.js library into ownCloud. Using this application users can view their PDF files in their browser without the need to download the file.
 
-        When this application is enabled publicly shared PDF documents will also
-        get shown in the PDF Viewer instead of only showing a single static
-        snapshot of the document. The PDF viewer requires a modern browser and
-        will not work with Microsoft® Internet Explorer® versions below 9.
+When this application is enabled publicly shared PDF documents will also get shown in the PDF Viewer instead of only showing a single static snapshot of the document. The PDF viewer requires a modern browser and will not work with Microsoft® Internet Explorer® versions below 9.
 
-        PDF.js is a JavaScript library developed by Mozilla, you can learn more
-        about the PDF.js project at https://mozilla.github.io/pdf.js/
+PDF.js is a JavaScript library developed by Mozilla, you can learn more about the PDF.js project at https://mozilla.github.io/pdf.js/
     </description>
     <licence>AGPL</licence>
     <author>Thomas Müller, Lukas Reschke, Viktar Dubiniuk</author>
@@ -22,11 +16,6 @@
         <owncloud min-version="10.0" max-version="11.0" />
     </dependencies>
     <default_enable/>
-    <documentation>
-    	<user>https://doc.owncloud.org/missing</user>
-    	<admin>https://doc.owncloud.org/missing</admin>
-    	<developer>https://doc.owncloud.org/missing</developer>
-    </documentation>
     <website>https://github.com/owncloud/files_pdfviewer</website>
     <bugs>https://github.com/owncloud/files_pdfviewer/issues</bugs>
     <category>productivity</category>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,7 +17,7 @@
     </description>
     <licence>AGPL</licence>
     <author>Thomas Müller, Lukas Reschke</author>
-    <version>0.8.2</version>
+    <version>0.9.0</version>
     <dependencies>
         <owncloud min-version="10.0" max-version="11.0" />
     </dependencies>


### PR DESCRIPTION
Note: the tag for v0.8.2 was missing, I didn't bother to go further in the past.