### PR TITLE
Fix tar argument order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
   only:
     - master
     - /^stable\d+(\.\d+)?$/
+    - /^release-[\.\d]+$/
 
 before_install:
   - nvm install --lts

--- a/Makefile
+++ b/Makefile
@@ -44,20 +44,7 @@ rebuild-pdfjs:
 
 # Builds the source and appstore package
 .PHONY: dist
-dist:
-	make source
-	make appstore
-
-# Builds the source package
-.PHONY: source
-source:
-	rm -rf $(source_build_directory)
-	mkdir -p $(source_build_directory)
-	tar cvzf $(source_package_name).tar.gz ../$(app_name) \
-	--exclude-vcs \
-	--exclude="../$(app_name)/build" \
-	--exclude="../$(app_name)/*.log" \
-	--exclude="../$(app_name)/js/*.log" \
+dist: appstore
 
 # Builds the source package for the app store, ignores php and js tests
 .PHONY: appstore


### PR DESCRIPTION
When running `make dist` it told me that the exclusion did not work due to argument order, so I fixed it here.