### PR TITLE
Provide clean-deps Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,13 @@ help:
 
 # Removes the appstore build
 .PHONY: clean
-clean:
+clean: clean-deps
 	rm -rf ./build/artifacts
+
+.PHONY: clean-deps
+clean-deps:
+	rm -Rf vendor
+	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 
 .PHONY: rebuild-pdfjs
 rebuild-pdfjs:


### PR DESCRIPTION
So that it is easy to clean the dependencies that get installed in ``vendor`` and ``vendor-bin``