### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ PDF.js is a JavaScript library developed by Mozilla, you can learn more about th
     <author>Thomas Müller, Lukas Reschke, Viktar Dubiniuk</author>
     <version>0.10.0</version>
     <dependencies>
-        <owncloud min-version="10" max-version="10" />
+        <owncloud min-version="10.2" max-version="10" />
     </dependencies>
     <default_enable/>
     <website>https://github.com/owncloud/files_pdfviewer</website>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/files_pdfviewer",
   "config" : {
     "platform": {
-      "php": "5.6.37"
+      "php": "7.0.8"
     }
   },
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "795909fd5d7967858d8080334aebcf14",
+    "content-hash": "d7bc519187b907e1b0e6417aa566761d",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
