### PR TITLE
Bind close button for attachments

### DIFF
--- a/js/workersrc.js
+++ b/js/workersrc.js
@@ -3,7 +3,7 @@
  **/
 function redirectIfNotDisplayedInFrame () {
 	try {
-		if (window.frameElement || location.href.indexOf('?file=blob') !== false) {
+		if (window.frameElement || location.href.indexOf('?file=blob') !== -1) {
 			return;
 		}
 	} catch (e) {}
@@ -13,6 +13,14 @@ function redirectIfNotDisplayedInFrame () {
 redirectIfNotDisplayedInFrame();
 
 function deferredViewerConfig() {
+	if (location.href.indexOf('?file=blob') !== -1) {
+		document.getElementById('secondaryToolbarClose').addEventListener(
+			'click',
+			function() {
+				window.close();
+			}
+		);
+	}
 	try {
 		PDFViewerApplicationOptions.set('workerSrc', document.getElementsByTagName('head')[0].getAttribute('data-workersrc'));
 		PDFViewerApplicationOptions.set('locale', parent.OC.getLocale());

--- a/tests/unit/controller/displaycontrollertest.php
+++ b/tests/unit/controller/displaycontrollertest.php
@@ -26,7 +26,7 @@ class DisplayControllerTest extends TestCase {
 	/** @var DisplayController */
 	private $controller;
 
-	public function setUp() {
+	public function setUp(): void {
 		$this->appName = 'files_pdfviewer';
 
 		$this->request = $this->getMockBuilder(


### PR DESCRIPTION
### Steps to reproduce
1- Open attachments inside pdf document
2 - Try to close the attachment using the close cross Icon of the files pdfviewer.

Fixes #203 
includes https://github.com/owncloud/files_pdfviewer/pull/200