### PR TITLE
Fix load of character maps to allow proper rendering of some fonts

### DIFF
--- a/js/workersrc.js
+++ b/js/workersrc.js
@@ -24,6 +24,7 @@ function deferredViewerConfig() {
 	try {
 		PDFViewerApplicationOptions.set('workerSrc', document.getElementsByTagName('head')[0].getAttribute('data-workersrc'));
 		PDFViewerApplicationOptions.set('locale', parent.OC.getLocale());
+		PDFViewerApplicationOptions.set('cMapUrl', document.getElementsByTagName('head')[0].getAttribute('data-cmapurl'));
 	} catch (e) {}
 	pdfjsLib.externalLinkTarget = pdfjsLib.LinkTarget.BLANK;
 	pdfjsLib.isEvalSupported = false;

--- a/templates/viewer.php
+++ b/templates/viewer.php
@@ -27,7 +27,8 @@ Adobe CMap resources are covered by their own copyright but the same license:
 See https://github.com/adobe-type-tools/cmap-resources
 -->
 <html dir="ltr" mozdisallowselectionprint moznomarginboxes>
-  <head data-workersrc="<?php p($urlGenerator->linkTo('files_pdfviewer', 'js/vendor/pdfjs/build/pdf.worker.js')) ?>?v=<?php p($version) ?>">
+  <head data-workersrc="<?php p($urlGenerator->linkTo('files_pdfviewer', 'js/vendor/pdfjs/build/pdf.worker.js')) ?>?v=<?php p($version) ?>"
+        data-cmapurl="<?php p($urlGenerator->linkTo('files_pdfviewer', 'js/vendor/pdfjs/web/cmaps/')) ?>">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <meta name="google" content="notranslate">


### PR DESCRIPTION
## Description

The character maps are used by pdfjs for font rendering and are needed to properly show some characters. The pdfjs package already provides the needed character maps, but the URL to get them must be correctly set.

## How Has This Been Tested?

Manually: open a pdf document containing Japanese characters through the files_pdfviewer app and check that fonts are correctly displayed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised