### PR TITLE
Allow Downloads in iframe. Fixes #214

### DIFF
--- a/js/previewplugin.js
+++ b/js/previewplugin.js
@@ -48,7 +48,7 @@
 			var viewer = OC.generateUrl('/apps/files_pdfviewer/?file={file}', {
 				file: downloadUrl
 			});
-			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:10;" src="' + viewer + '" sandbox="allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" />');
+			$iframe = $('<iframe id="pdframe" style="width:100%;height:100%;display:block;position:absolute;top:0;z-index:10;" src="' + viewer + '" sandbox="allow-downloads allow-scripts allow-same-origin allow-popups allow-modals allow-top-navigation" />');
 
 			if (isFileList === true) {
 				FileList.setViewerMode(true);


### PR DESCRIPTION
In chrome 83 an iframe is not allowed to initiate a download except when the sandbox=allow-downloads attribute is set.
Same as https://github.com/nextcloud/files_pdfviewer/pull/186