### PR TITLE
[tests-only] Adjust phpstan.neon bootstrapFiles

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
   inferPrivatePropertyTypeFromConstructor: true
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   ignoreErrors:
 


### PR DESCRIPTION
To avoid getting:
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
⚠️  You're using a deprecated config option bootstrap. ⚠️️

This option has been replaced with bootstrapFiles which accepts a list of files
to execute before the analysis.
```

I missed doing this in recent  updates of CI infrastructure.