### PR TITLE
fix wrong locale

### DIFF
--- a/js/workersrc.js
+++ b/js/workersrc.js
@@ -1,6 +1,7 @@
 /**
  * Checks if the page is displayed in an iframe. If not redirect to /.
  **/
+
 function redirectIfNotDisplayedInFrame () {
 	try {
 		if (window.frameElement || location.href.indexOf('?file=blob') !== -1) {
@@ -23,7 +24,7 @@ function deferredViewerConfig() {
 	}
 	try {
 		PDFViewerApplicationOptions.set('workerSrc', document.getElementsByTagName('head')[0].getAttribute('data-workersrc'));
-		PDFViewerApplicationOptions.set('locale', parent.OC.getLocale());
+		PDFViewerApplicationOptions.set('locale', getSanitizedCurrentLocale());
 		PDFViewerApplicationOptions.set('cMapUrl', document.getElementsByTagName('head')[0].getAttribute('data-cmapurl'));
 		PDFViewerApplicationOptions.set('printResolution', 300);
 	} catch (e) {}
@@ -31,5 +32,10 @@ function deferredViewerConfig() {
 	pdfjsLib.isEvalSupported = false;
 }
 
+function getSanitizedCurrentLocale(){
+	return parent.OC.getLocale().replace('_', '-');
+}
+
 // Wait until viewer is ready and patch it on the fly
 parent.document.addEventListener('webviewerloaded', deferredViewerConfig, true);
+parent.document.documentElement.lang = getSanitizedCurrentLocale();


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/38526 hitting the following problem:

In settings -> chaning language to 'Deutsch förmlich (Sie)' will set the locale to de_De. 
PDFJS gets the locale via top html lang attribute and only supports dash locale identifiers for e.G de-De and falls back to english.




