### PR TITLE
Possible fix for "Missing L10N Folder in Marketplace Release"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ appstore:
 	appinfo \
 	lib \
 	templates \
+	l10n \
 	css \
 	img \
 	js \


### PR DESCRIPTION
Fixes: #279