### PR TITLE
ci: add lint PR title workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,16 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds the `lint-pr-title` GitHub Actions workflow to enforce semantic PR titles
- Uses `amannn/action-semantic-pull-request` (pinned to SHA `48f256284bd46cdaab1048c3721360e808335d50`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)