### PR TITLE
fix: mitigate CVE-2024-4367 FontMatrix code injection in pdf viewer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
       - name: Run CVE regression checks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
       - name: Run CVE regression checks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,3 +54,16 @@ jobs:
     with:
       app-name: ${{ needs.get-vars.outputs.app-name }}
       php-versions: ${{ needs.get-vars.outputs.php-versions }}
+
+  security:
+    name: Security regression checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run CVE regression checks
+        run: make test-security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] 
 
--
+### Fixes
+
+- Fix CVE-2024-4367: reject a non-numeric `/FontMatrix` and coerce glyph command
+  arguments to numbers so a malicious PDF font cannot inject JavaScript into the
+  pdf.js renderer, make the `isEvalSupported=false` hardening in `workersrc.js`
+  fail-safe, and explicitly disable `unsafe-eval` in the viewer
+  Content-Security-Policy (OC10-111)
 
 ## [1.0.2] - 2024-01-16
 

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,12 @@ test-php-unit-dbg: ## Run php unit tests using phpdbg
 test-php-unit-dbg:
 	$(PHPUNITDBG) --configuration ./phpunit.xml --testsuite unit
 
+.PHONY: test-security
+test-security: ## Run the CVE regression checks (node)
+test-security:
+	node tests/security/verify-cve-2024-4367.mjs
+	node tests/security/test-blob-popup-detection.mjs
+
 .PHONY: test-php-style
 test-php-style: ## Run php-cs-fixer and check owncloud code-style
 test-php-style: vendor-bin/owncloud-codestyle/vendor

--- a/js/vendor/pdfjs/build/pdf.js
+++ b/js/vendor/pdfjs/build/pdf.js
@@ -13233,7 +13233,23 @@ var FontFaceObject = /*#__PURE__*/function () {
         try {
           for (_iterator3.s(); !(_step3 = _iterator3.n()).done;) {
             var current = _step3.value;
-            var args = current.args !== undefined ? current.args.join(",") : "";
+            var args = "";
+
+            if (current.args !== undefined) {
+              if (current.cmd === "scale") {
+                // The scale command intentionally passes the "size"/"-size"
+                // function parameters, not numeric literals.
+                args = current.args.join(",");
+              } else {
+                // CVE-2024-4367: never interpolate a non-number into the
+                // generated function body; replace anything that is not a
+                // number with 0.
+                args = current.args.map(function (arg) {
+                  return typeof arg === "number" ? arg : 0;
+                }).join(",");
+              }
+            }
+
             jsBuf.push("c.", current.cmd, "(", args, ");\n");
           }
         } catch (err) {

--- a/js/vendor/pdfjs/build/pdf.worker.js
+++ b/js/vendor/pdfjs/build/pdf.worker.js
@@ -22678,6 +22678,17 @@ var PartialEvaluator = /*#__PURE__*/function () {
                 isInternalFont = !!fontFile;
 
               case 73:
+                // CVE-2024-4367: reject a /FontMatrix that is not exactly six
+                // numbers so an attacker-controlled string cannot flow into the
+                // glyph command list (and, with eval, into new Function()).
+                var fontMatrix = dict.getArray("FontMatrix");
+
+                if (!Array.isArray(fontMatrix) || fontMatrix.length !== 6 || fontMatrix.some(function (x) {
+                  return typeof x !== "number";
+                })) {
+                  fontMatrix = _util.FONT_IDENTITY_MATRIX;
+                }
+
                 properties = {
                   type: type,
                   name: fontName.name,
@@ -22691,7 +22702,7 @@ var PartialEvaluator = /*#__PURE__*/function () {
                   loadedName: baseDict.loadedName,
                   composite: composite,
                   fixedPitch: false,
-                  fontMatrix: dict.getArray("FontMatrix") || _util.FONT_IDENTITY_MATRIX,
+                  fontMatrix: fontMatrix,
                   firstChar: firstChar,
                   lastChar: lastChar,
                   toUnicode: toUnicode,

--- a/js/workersrc.js
+++ b/js/workersrc.js
@@ -14,7 +14,13 @@ function isBlobDownloadPopup () {
 	for (var i = 0; i < params.length; i++) {
 		var pair = params[i].split('=');
 		if (pair[0] === 'file') {
-			var value = decodeURIComponent(pair.slice(1).join('='));
+			var value;
+			try {
+				value = decodeURIComponent(pair.slice(1).join('='));
+			} catch (e) {
+				// A malformed %-sequence is never a genuine blob: popup URL.
+				return false;
+			}
 			return value.indexOf('blob:') === 0;
 		}
 	}
@@ -50,6 +56,7 @@ function deferredViewerConfig() {
 		var head = document.getElementsByTagName('head')[0];
 		enableScripting = head.getAttribute('data-enableScripting') === 'true';
 	} catch (e) {
+		// best-effort; keep the safe default (scripting disabled)
 	}
 	PDFViewerApplicationOptions.set('enableScripting', enableScripting);
 
@@ -70,6 +77,7 @@ function deferredViewerConfig() {
 		PDFViewerApplicationOptions.set('printResolution', 300);
 		PDFViewerApplicationOptions.set('externalLinkTarget', pdfjsLib.LinkTarget.BLANK);
 	} catch (e) {
+		// best-effort; the security-relevant options above are already set
 	}
 
 	// The locale lookup dereferences parent.OC and may throw when the viewer
@@ -78,6 +86,7 @@ function deferredViewerConfig() {
 	try {
 		PDFViewerApplicationOptions.set('locale', getSanitizedCurrentLocale());
 	} catch (e) {
+		// best-effort; locale is cosmetic and must not abort config
 	}
 }
 
@@ -90,4 +99,5 @@ parent.document.addEventListener('webviewerloaded', deferredViewerConfig, true);
 try {
 	parent.document.documentElement.lang = getSanitizedCurrentLocale();
 } catch (e) {
+	// best-effort; lang attribute is cosmetic
 }

--- a/js/workersrc.js
+++ b/js/workersrc.js
@@ -1,10 +1,33 @@
 /**
- * Checks if the page is displayed in an iframe. If not redirect to /.
+ * Returns true if the viewer was opened as the standalone attachment popup,
+ * i.e. window.open('?file=blob:...') from the pdf.js viewer. The genuine
+ * indicator is the "file" *query* parameter holding a blob: URL. We parse the
+ * actual query parameter instead of doing a loose substring match on the whole
+ * URL (the old `indexOf('?file=blob')` check), because that match could be
+ * satisfied from an unrelated part of the URL - notably the hash fragment,
+ * which an attacker fully controls (e.g. "...#?file=blob") to force the viewer
+ * out of its iframe.
  **/
+function isBlobDownloadPopup () {
+	var query = location.search.replace(/^\?/, '');
+	var params = query.split('&');
+	for (var i = 0; i < params.length; i++) {
+		var pair = params[i].split('=');
+		if (pair[0] === 'file') {
+			var value = decodeURIComponent(pair.slice(1).join('='));
+			return value.indexOf('blob:') === 0;
+		}
+	}
+	return false;
+}
 
+/**
+ * Checks if the page is displayed in an iframe or as the blob download popup.
+ * If neither, redirect to /.
+ **/
 function redirectIfNotDisplayedInFrame () {
 	try {
-		if (window.frameElement || location.href.indexOf('?file=blob') !== -1) {
+		if (window.frameElement || isBlobDownloadPopup()) {
 			return;
 		}
 	} catch (e) {}
@@ -14,25 +37,46 @@ function redirectIfNotDisplayedInFrame () {
 redirectIfNotDisplayedInFrame();
 
 function deferredViewerConfig() {
-	if (location.href.indexOf('?file=blob') !== -1) {
-		document.getElementById('secondaryToolbarClose').addEventListener(
-			'click',
-			function() {
-				window.close();
-			}
-		);
-	}
+	// Security hardening (CVE-2024-4367): disable eval-based rendering and
+	// scripting FIRST and unconditionally, before any statement that might
+	// throw. Previously a throwing locale lookup could abort this function
+	// before isEvalSupported was set, silently leaving eval enabled and the
+	// FontMatrix code-injection sink reachable.
+	PDFViewerApplicationOptions.set('isEvalSupported', false);
+	PDFViewerApplicationOptions.set('disablePreferences', true);
+
+	var enableScripting = false;
 	try {
-		var head = document.getElementsByTagName('head')[0]
-		PDFViewerApplicationOptions.set('disablePreferences', true);
-		PDFViewerApplicationOptions.set('workerSrc', head.getAttribute('data-workersrc'));
-		PDFViewerApplicationOptions.set('locale', getSanitizedCurrentLocale());
-		PDFViewerApplicationOptions.set('cMapUrl', head.getAttribute('data-cmapurl'));
-		PDFViewerApplicationOptions.set('sandboxBundleSrc', head.getAttribute('data-sandbox'));
+		var head = document.getElementsByTagName('head')[0];
+		enableScripting = head.getAttribute('data-enableScripting') === 'true';
+	} catch (e) {
+	}
+	PDFViewerApplicationOptions.set('enableScripting', enableScripting);
+
+	if (isBlobDownloadPopup()) {
+		var closeButton = document.getElementById('secondaryToolbarClose');
+		if (closeButton) {
+			closeButton.addEventListener('click', function() {
+				window.close();
+			});
+		}
+	}
+
+	try {
+		var headEl = document.getElementsByTagName('head')[0];
+		PDFViewerApplicationOptions.set('workerSrc', headEl.getAttribute('data-workersrc'));
+		PDFViewerApplicationOptions.set('cMapUrl', headEl.getAttribute('data-cmapurl'));
+		PDFViewerApplicationOptions.set('sandboxBundleSrc', headEl.getAttribute('data-sandbox'));
 		PDFViewerApplicationOptions.set('printResolution', 300);
 		PDFViewerApplicationOptions.set('externalLinkTarget', pdfjsLib.LinkTarget.BLANK);
-		PDFViewerApplicationOptions.set('isEvalSupported', false);
-		PDFViewerApplicationOptions.set('enableScripting', head.getAttribute('data-enableScripting') === 'true');
+	} catch (e) {
+	}
+
+	// The locale lookup dereferences parent.OC and may throw when the viewer
+	// runs top-level (e.g. the blob popup); isolate it so it can never abort
+	// the security-relevant option above.
+	try {
+		PDFViewerApplicationOptions.set('locale', getSanitizedCurrentLocale());
 	} catch (e) {
 	}
 }
@@ -43,4 +87,7 @@ function getSanitizedCurrentLocale(){
 
 // Wait until viewer is ready and patch it on the fly
 parent.document.addEventListener('webviewerloaded', deferredViewerConfig, true);
-parent.document.documentElement.lang = getSanitizedCurrentLocale();
+try {
+	parent.document.documentElement.lang = getSanitizedCurrentLocale();
+} catch (e) {
+}

--- a/lib/Controller/DisplayController.php
+++ b/lib/Controller/DisplayController.php
@@ -61,7 +61,11 @@ class DisplayController extends Controller {
 		$policy->addAllowedFontDomain('data:');
 		$policy->addAllowedImageDomain('*');
 		$policy->addAllowedConnectDomain('blob: data:');
-		$policy->allowEvalScript(true);
+		// CVE-2024-4367: the patched pdf.js no longer needs eval for rendering.
+		// ContentSecurityPolicy allows 'unsafe-eval' by default, so we must
+		// explicitly disable it (not merely omit allowEvalScript(true)) to make
+		// the new Function() font-rendering sink unreachable in the browser.
+		$policy->allowEvalScript(false);
 		$response->setContentSecurityPolicy($policy);
 
 		return $response;

--- a/tests/security/README.md
+++ b/tests/security/README.md
@@ -1,0 +1,43 @@
+# Security regression fixtures
+
+## CVE-2024-4367 — FontMatrix code injection (OC10-111)
+
+`cve-2024-4367-poc.pdf` embeds a `/FontMatrix` whose sixth element is a
+JavaScript string instead of a number. On a vulnerable build (pdf.js with the
+eval-based glyph compiler and `isEvalSupported` effectively `true`) opening this
+document executes the payload in the viewer origin. The bundled payload is
+benign: it only sets `globalThis.__cve_2024_4367__ = 'reached'` and the document
+title, so it can be used to confirm exploitation without side effects.
+
+### Automated check
+
+`verify-cve-2024-4367.mjs` reproduces the two backported guards in isolation and
+asserts that:
+
+* a `/FontMatrix` that is not exactly six numbers is replaced by the identity
+  matrix (evaluator guard), and
+* the glyph-command sink coerces every non-number argument to `0`, so no
+  attacker string can reach `new Function(...)`, while the intentional `scale`
+  identifiers are preserved.
+
+Run with `node tests/security/verify-cve-2024-4367.mjs`; every line must print
+`true`.
+
+`test-blob-popup-detection.mjs` covers the `workersrc.js` frame-escape guard: it
+asserts that the genuine `?file=blob:...` attachment popup is allowed while an
+attacker-controlled `#?file=blob` hash fragment (which defeated the old
+`indexOf('?file=blob')` substring check) is rejected. Run with
+`node tests/security/test-blob-popup-detection.mjs`; every line must print
+`PASS`.
+
+### Manual end-to-end check
+
+1. Serve the app and open `cve-2024-4367-poc.pdf` in the pdf viewer.
+2. In the browser console, evaluate `window.__cve_2024_4367__`.
+   * Vulnerable: `'reached'` (the payload ran).
+   * Fixed: `undefined` (the payload never executed).
+
+The fix is defended at three independent layers: the FontMatrix type check and
+the sink coercion in the bundled pdf.js, the fail-safe `isEvalSupported=false`
+ordering in `js/workersrc.js`, and the removal of `allowEvalScript(true)` from
+the Content-Security-Policy in `DisplayController`.

--- a/tests/security/README.md
+++ b/tests/security/README.md
@@ -11,6 +11,9 @@ title, so it can be used to confirm exploitation without side effects.
 
 ### Automated check
 
+Run all of these with `make test-security`; they also run on every PR via the
+`Security regression checks` CI job. Each script exits non-zero on failure.
+
 `verify-cve-2024-4367.mjs` reproduces the two backported guards in isolation and
 asserts that:
 
@@ -20,14 +23,18 @@ asserts that:
   attacker string can reach `new Function(...)`, while the intentional `scale`
   identifiers are preserved.
 
-Run with `node tests/security/verify-cve-2024-4367.mjs`; every line must print
-`true`.
+> **Drift caveat:** guards A and B in this script are *reproductions* of the
+> logic, not the shipped code — the real code lives in a minified vendor bundle
+> that cannot be imported. To catch the bundle regressing away from these
+> reproductions (e.g. on a future pdf.js upgrade that drops the backport), the
+> script's "source tripwire" section (checks `S1`–`S4`) reads the actual
+> `pdf.js` / `pdf.worker.js` and fails if the guards are no longer present. The
+> manual end-to-end check below remains the authoritative verification.
 
 `test-blob-popup-detection.mjs` covers the `workersrc.js` frame-escape guard: it
 asserts that the genuine `?file=blob:...` attachment popup is allowed while an
 attacker-controlled `#?file=blob` hash fragment (which defeated the old
-`indexOf('?file=blob')` substring check) is rejected. Run with
-`node tests/security/test-blob-popup-detection.mjs`; every line must print
+`indexOf('?file=blob')` substring check) is rejected. Every line must print
 `PASS`.
 
 ### Manual end-to-end check

--- a/tests/security/cve-2024-4367-poc.pdf
+++ b/tests/security/cve-2024-4367-poc.pdf
@@ -1,0 +1,81 @@
+%PDF-1.4
+%DUMMY
+8 0 obj
+<<
+/PatternType 2
+/Shading<< /Function<< /Domain[0 1] /C0[0 0 1] /C1[1 0.6 0] /N 1 /FunctionType 2 >>
+  /ShadingType 2 /Coords[46 400 537 400] /Extend[false false] /ColorSpace/DeviceRGB >>
+/Type/Pattern
+>>
+endobj
+5 0 obj
+<<
+/Widths[573 0 582 0 548 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 573 0 573 0 341]
+/Type/Font
+/BaseFont/PAXEKO+SourceSansPro-Bold
+/LastChar 102
+/Encoding/WinAnsiEncoding
+/FontMatrix [0.1 0 0 0.1 0 (1\);
+globalThis.__cve_2024_4367__ = 'reached'; if \(typeof document !== 'undefined'\) { document.title = 'XSS@' + document.domain; }
+//)]
+/Subtype/Type1
+/FirstChar 65
+/FontDescriptor 9 0 R
+>>
+endobj
+2 0 obj
+<< /Kids[3 0 R] /Type/Pages /Count 1 >>
+endobj
+9 0 obj
+<< /Type/FontDescriptor /ItalicAngle 0 /Ascent 751 /FontBBox[-6 -12 579 713]
+/FontName/PAXEKO+SourceSansPro-Bold /StemV 100 /CapHeight 713 /Flags 32
+/FontFile3 10 0 R /Descent -173 /MissingWidth 250 >>
+endobj
+6 0 obj
+<< /Length 128 >>
+stream
+47 379 489 230 re S
+/Pattern cs
+BT
+  50 500 Td
+  117 TL
+  /F1 150 Tf
+  /P1 scn
+  (AbCdEf) Tj
+  /P2 scn
+  (AbCdEf) '
+ET
+endstream
+endobj
+3 0 obj
+<< /Type/Page /Resources 4 0 R /Contents 6 0 R /Parent 2 0 R /MediaBox[0 0 595.2756 841.8898] >>
+endobj
+10 0 obj
+<< /Length 800 /Subtype/Type2 >>
+stream
+
+endstream
+endobj
+7 0 obj
+<< /PatternType 1 /Matrix[1 0 0 1 50 0] /Length 58 /TilingType 1 /BBox[0 0 16 16]
+/YStep 16 /PaintType 1 /Resources<< >> /XStep 16 >>
+stream
+0.65 g
+0 0 16 16 re f
+0.15 g
+0 0 8 8 re f
+8 8 8 8 re f
+endstream
+endobj
+4 0 obj
+<< /Pattern<< /P1 7 0 R /P2 8 0 R >> /Font<< /F1 5 0 R >> >>
+endobj
+1 0 obj
+<< /Pages 2 0 R /Type/Catalog /OpenAction[3 0 R /Fit] >>
+endobj
+
+trailer
+<< /ID[(DUMMY) (DUMMY)] /Root 1 0 R /Size 11 >>
+startxref
+0
+%%EOF

--- a/tests/security/test-blob-popup-detection.mjs
+++ b/tests/security/test-blob-popup-detection.mjs
@@ -1,0 +1,30 @@
+function isBlobDownloadPopup(location) {
+	var query = location.search.replace(/^\?/, '');
+	var params = query.split('&');
+	for (var i = 0; i < params.length; i++) {
+		var pair = params[i].split('=');
+		if (pair[0] === 'file') {
+			var value = decodeURIComponent(pair.slice(1).join('='));
+			return value.indexOf('blob:') === 0;
+		}
+	}
+	return false;
+}
+const cases = [
+  // legit attachment popup: window.open("?file=" + encodeURIComponent("blob:...#name"))
+  [{search: "?file=" + encodeURIComponent("blob:https://host/uuid#a.pdf")}, true, "legit blob popup"],
+  // attacker trick: file=blob only in the hash to fool the old substring guard
+  [{search: "?file=/s/TOKEN/download", hash: "#?file=blob"}, false, "attacker hash #?file=blob"],
+  // normal iframe render: query has a download URL (also framed, but test the parser)
+  [{search: "?file=" + encodeURIComponent("/s/TOKEN/download")}, false, "normal download url"],
+  // no params
+  [{search: ""}, false, "empty"],
+];
+let ok = true;
+for (const [loc, expected, name] of cases) {
+  const got = isBlobDownloadPopup({search: loc.search || "", hash: loc.hash || ""});
+  const pass = got === expected;
+  ok = ok && pass;
+  console.log((pass?"PASS":"FAIL"), name, "->", got);
+}
+process.exit(ok?0:1);

--- a/tests/security/verify-cve-2024-4367.mjs
+++ b/tests/security/verify-cve-2024-4367.mjs
@@ -1,0 +1,61 @@
+// Verify the two backported guards behave correctly against the PoC payload.
+const FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
+
+// ---- Guard A: evaluator FontMatrix type-check (as backported) ----
+function sanitizeFontMatrix(raw) {
+  let fontMatrix = raw;
+  if (!Array.isArray(fontMatrix) || fontMatrix.length !== 6 ||
+      fontMatrix.some(x => typeof x !== "number")) {
+    fontMatrix = FONT_IDENTITY_MATRIX;
+  }
+  return fontMatrix;
+}
+
+// The PoC's /FontMatrix parses to 6 elements where the last is the attacker
+// string. Simulate what dict.getArray("FontMatrix") yields:
+const maliciousPayload = "1);\nglobalThis.__cve_2024_4367__='reached';\n//";
+const attackerMatrix = [0.1, 0, 0, 0.1, 0, maliciousPayload]; // 6 elems, one non-number
+const benignMatrix = [0.001, 0, 0, 0.001, 0, 0];
+
+console.log("A1 malicious rejected ->",
+  JSON.stringify(sanitizeFontMatrix(attackerMatrix)) === JSON.stringify(FONT_IDENTITY_MATRIX));
+console.log("A2 benign preserved   ->",
+  JSON.stringify(sanitizeFontMatrix(benignMatrix)) === JSON.stringify(benignMatrix));
+console.log("A3 wrong-length rejected ->",
+  JSON.stringify(sanitizeFontMatrix([1,2,3])) === JSON.stringify(FONT_IDENTITY_MATRIX));
+
+// ---- Guard B: sink numeric coercion (as backported) ----
+function buildBody(cmds) {
+  const jsBuf = [];
+  for (const current of cmds) {
+    let args = "";
+    if (current.args !== undefined) {
+      if (current.cmd === "scale") {
+        args = current.args.join(",");
+      } else {
+        args = current.args.map(a => (typeof a === "number" ? a : 0)).join(",");
+      }
+    }
+    jsBuf.push("c.", current.cmd, "(", args, ");\n");
+  }
+  return jsBuf.join("");
+}
+
+// If guard A somehow failed, the sink still gets the attacker string as a transform arg.
+const cmdsIfGuardAFailed = [
+  { cmd: "save" },
+  { cmd: "transform", args: [0.1,0,0,0.1,0, maliciousPayload] },
+  { cmd: "scale", args: ["size","-size"] },
+];
+const body = buildBody(cmdsIfGuardAFailed);
+console.log("B1 no payload in body ->", !body.includes("__cve_2024_4367__"));
+console.log("B2 scale identifiers kept ->", body.includes("c.scale(size,-size)"));
+// Ensure the generated body is still valid JS and runs harmlessly
+globalThis.__cve_2024_4367__ = undefined;
+const fn = new Function("c","size", body);
+const calls = [];
+const ctx = new Proxy({}, { get: () => (...a)=>calls.push(a) });
+fn(ctx, 10);
+console.log("B3 body executed w/o injection ->", globalThis.__cve_2024_4367__ === undefined);
+console.log("B4 transform got numeric 0 for bad arg ->",
+  JSON.stringify(calls.find(c=>c.length===6)) === JSON.stringify([0.1,0,0,0.1,0,0]));

--- a/tests/security/verify-cve-2024-4367.mjs
+++ b/tests/security/verify-cve-2024-4367.mjs
@@ -1,4 +1,26 @@
 // Verify the two backported guards behave correctly against the PoC payload.
+//
+// NOTE: Guards A and B below re-declare the backported logic so it can be
+// exercised in isolation - the shipped code lives in a minified vendor bundle
+// that cannot be imported directly. To catch the bundle silently drifting away
+// from these reproductions, the "source tripwire" section at the end reads the
+// actual pdf.js / pdf.worker.js files and fails if the guards disappear.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..", "..");
+
+let failures = 0;
+function check(name, condition) {
+  const ok = condition === true;
+  console.log((ok ? "PASS" : "FAIL"), name, "->", condition);
+  if (!ok) {
+    failures++;
+  }
+}
+
 const FONT_IDENTITY_MATRIX = [0.001, 0, 0, 0.001, 0, 0];
 
 // ---- Guard A: evaluator FontMatrix type-check (as backported) ----
@@ -17,11 +39,11 @@ const maliciousPayload = "1);\nglobalThis.__cve_2024_4367__='reached';\n//";
 const attackerMatrix = [0.1, 0, 0, 0.1, 0, maliciousPayload]; // 6 elems, one non-number
 const benignMatrix = [0.001, 0, 0, 0.001, 0, 0];
 
-console.log("A1 malicious rejected ->",
+check("A1 malicious rejected",
   JSON.stringify(sanitizeFontMatrix(attackerMatrix)) === JSON.stringify(FONT_IDENTITY_MATRIX));
-console.log("A2 benign preserved   ->",
+check("A2 benign preserved",
   JSON.stringify(sanitizeFontMatrix(benignMatrix)) === JSON.stringify(benignMatrix));
-console.log("A3 wrong-length rejected ->",
+check("A3 wrong-length rejected",
   JSON.stringify(sanitizeFontMatrix([1,2,3])) === JSON.stringify(FONT_IDENTITY_MATRIX));
 
 // ---- Guard B: sink numeric coercion (as backported) ----
@@ -48,14 +70,36 @@ const cmdsIfGuardAFailed = [
   { cmd: "scale", args: ["size","-size"] },
 ];
 const body = buildBody(cmdsIfGuardAFailed);
-console.log("B1 no payload in body ->", !body.includes("__cve_2024_4367__"));
-console.log("B2 scale identifiers kept ->", body.includes("c.scale(size,-size)"));
+check("B1 no payload in body", !body.includes("__cve_2024_4367__"));
+check("B2 scale identifiers kept", body.includes("c.scale(size,-size)"));
 // Ensure the generated body is still valid JS and runs harmlessly
 globalThis.__cve_2024_4367__ = undefined;
 const fn = new Function("c","size", body);
 const calls = [];
 const ctx = new Proxy({}, { get: () => (...a)=>calls.push(a) });
 fn(ctx, 10);
-console.log("B3 body executed w/o injection ->", globalThis.__cve_2024_4367__ === undefined);
-console.log("B4 transform got numeric 0 for bad arg ->",
+check("B3 body executed w/o injection", globalThis.__cve_2024_4367__ === undefined);
+check("B4 transform got numeric 0 for bad arg",
   JSON.stringify(calls.find(c=>c.length===6)) === JSON.stringify([0.1,0,0,0.1,0,0]));
+
+// ---- Source tripwire: the guards must still be present in the shipped bundle ----
+// These are coarse substring checks. They cannot prove the guard is wired up
+// correctly, but they fail loudly if the bundle is regenerated/upgraded without
+// carrying the backport forward - which is the realistic regression path.
+const workerSrc = readFileSync(join(repoRoot, "js/vendor/pdfjs/build/pdf.worker.js"), "utf8");
+const pdfSrc = readFileSync(join(repoRoot, "js/vendor/pdfjs/build/pdf.js"), "utf8");
+
+check("S1 worker FontMatrix length guard present",
+  workerSrc.includes("fontMatrix.length !== 6"));
+check("S2 worker FontMatrix type guard present",
+  /fontMatrix\.some\(function \(x\) \{\s*return typeof x !== "number";/.test(workerSrc));
+check("S3 pdf.js glyph-arg numeric coercion present",
+  /typeof arg === "number" \? arg : 0/.test(pdfSrc));
+check("S4 pdf.js preserves intentional scale identifiers",
+  pdfSrc.includes('current.cmd === "scale"'));
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll checks passed");

--- a/tests/unit/Controller/DisplayControllerTest.php
+++ b/tests/unit/Controller/DisplayControllerTest.php
@@ -72,7 +72,9 @@ class DisplayControllerTest extends TestCase {
 		$policy->addAllowedFontDomain('data:');
 		$policy->addAllowedImageDomain('*');
 		$policy->addAllowedConnectDomain('blob: data:');
-		$policy->allowEvalScript(true);
+		// CVE-2024-4367: the patched pdf.js no longer needs eval for rendering,
+		// so the controller explicitly disables 'unsafe-eval' in the CSP.
+		$policy->allowEvalScript(false);
 		$expectedResponse->setContentSecurityPolicy($policy);
 
 		$this->assertEquals($expectedResponse, $this->controller->showPdfViewer());


### PR DESCRIPTION
## Summary

Mitigates **CVE-2024-4367** (FontMatrix code injection) in the bundled pdf.js. A missing type check on the PDF `/FontMatrix` attribute allowed an attacker-controlled string to flow into `new Function()` in the glyph renderer, executing JavaScript in the viewer origin (XSS → account takeover through a public share / attachment popup).

The pre-existing `isEvalSupported=false` hardening was bypassable: in `workersrc.js` it was set *after* a locale lookup (`parent.OC.getLocale()`) inside a single `try` with a bare `catch`. When the viewer runs top-level (the `?file=blob` popup) `parent.OC` can throw, the `catch` swallows it, and eval stays enabled. The viewer CSP also explicitly allowed `unsafe-eval`.

## Changes (defense in depth)

- **`pdf.worker.js`** — backport the upstream type check: a `/FontMatrix` that is not exactly six numbers is replaced by the identity matrix.
- **`pdf.js`** — coerce every glyph-command argument to a number before it is interpolated into `new Function()` (the intentional `scale` identifiers are preserved).
- **`workersrc.js`** — set `isEvalSupported=false` and `enableScripting` first and unconditionally; isolate the throwing locale lookup; detect the blob popup by parsing the `file` **query** parameter for a `blob:` URL instead of a loose `indexOf('?file=blob')` substring match (which was satisfiable from the attacker-controlled URL hash).
- **`DisplayController`** — drop `allowEvalScript(true)` so the `new Function` sink is unreachable in the browser.

## Tests

Adds `tests/security/` with the PoC PDF (benign marker payload), node verification harnesses for both source guards, and a blob-popup detection test. All pass locally.

## Follow-up

This backports the CVE fix into the current pdf.js 3.15.2 bundle. Upgrading the bundle to pdf.js ≥ 4.2.67 remains a recommended larger follow-up.

Fixes OC10-111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
