### PR TITLE
ci: add signed release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: owncloud/reusable-workflows/.github/workflows/release.yml@main
+    with:
+      app-name: files_pdfviewer
+      artifact-glob: build/artifacts/appstore/files_pdfviewer.tar.gz
+    secrets:
+      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      SIGNING_CERT: ${{ secrets.SIGNING_CERT }}
+      SIGNING_CHAIN: ${{ secrets.SIGNING_CHAIN }}


### PR DESCRIPTION
Adds the tag-triggered caller for the shared signed-release workflow
(`owncloud/reusable-workflows/.github/workflows/release.yml@main`).

Pushing a `v*` tag now builds the app on a runner, signs it with this repo's G2
leaf certificate via [`ocsign`](https://github.com/owncloud/ocsign), asserts the
artifact really carries `appinfo/signature.json` — a silently unsigned build is a
hard failure rather than a published release — and creates the GitHub Release
with the tarball attached.

The signing key material comes from the `SIGNING_KEY` / `SIGNING_CERT` /
`SIGNING_CHAIN` repository secrets, already enrolled here. Nothing changes for
existing pushes or pull requests; the workflow only fires on tags.

No release is triggered by merging this PR.